### PR TITLE
Drop PHP 5.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.6
     - 7.0
     - 7.1
-    - hhvm
 
 branches:
     except:
@@ -19,7 +17,7 @@ branches:
 matrix:
     fast_finish: true
     include:
-        - php: 5.6
+        - php: 7.0
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.0"
     },
     "require-dev": {
         "doctrine/cache": "^1.5",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no|yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #2
| License         | MIT


#### What's in this PR?

Drops support for PHP 5.x


#### Why?

Because it's 2017


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
