### PR TITLE
Add PSR-3 logger, closes #1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "doctrine/cache": "^1.5",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #1
| License         | MIT


#### What's in this PR?

Adds PSR-3 logger to log handled exceptions.


#### Why?

The built-in `SessionHandlerInterface` requires empty values to be returned upon an error, thus error handling for the backends is built into the handlers. In order to get notified about errors, a logger has been added.
